### PR TITLE
Automatic build multi-arch image using github workflow

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -24,8 +24,6 @@ jobs:
           - amd64
           - arm64
           - arm/v7
-          - ppc64le
-          - s390x
           - 386
     steps:
     - name: Checkout code from Git repository
@@ -88,8 +86,6 @@ jobs:
                                ${IMAGE_ID}:${{ env.BRANCH_NAME }}-amd64 \
                                ${IMAGE_ID}:${{ env.BRANCH_NAME }}-arm64 \
                                ${IMAGE_ID}:${{ env.BRANCH_NAME }}-armv7 \
-                               ${IMAGE_ID}:${{ env.BRANCH_NAME }}-ppc64le \
-                               ${IMAGE_ID}:${{ env.BRANCH_NAME }}-s390x \
                                ${IMAGE_ID}:${{ env.BRANCH_NAME }}-386
         
         docker manifest push ${IMAGE_ID}:${{ env.BRANCH_NAME }}

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -1,0 +1,95 @@
+name: Build Vi-v
+
+on:
+  push:
+  pull_request:
+  schedule:
+# Cron execution is for weekly dependencies update (for security update)
+#             ┌───────────── minute (0 - 59)
+#             │ ┌───────────── hour (0 - 23)
+#             │ │ ┌───────────── day of the month (1 - 31)
+#             │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+#             │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    - cron:  '0 0 * * 0'
+
+jobs:
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: 
+          - amd64
+          - arm64
+          - arm/v7
+          - ppc64le
+          - s390x
+          - 386
+    steps:
+    - name: Checkout code from Git repository
+      uses: actions/checkout@v2
+    
+    - id: buildx
+      name: Set up Docker Buildx
+      uses: crazy-max/ghaction-docker-buildx@v1
+      with:
+        buildx-version: latest
+        qemu-version: latest
+    
+    - name: Log into registry
+      run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin
+        
+    - name: Build & Push
+      run: |
+        IMAGE_ID=shiishii/raspap
+        # Change all uppercase to lowercase
+        IMAGE_ID=$(echo ${IMAGE_ID} | tr '[A-Z]' '[a-z]')
+        # Strip git ref prefix from version
+        VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+        # Strip "v" prefix from tag name
+        [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo ${VERSION} | sed -e 's/^v//')
+        # Use Docker `latest` tag convention
+        [ "$VERSION" == "master" ] && VERSION=latest
+        if [ -n "${{ matrix.platform }}" ]; then
+          _platform=${{ matrix.platform }}
+          VERSION="${VERSION}-${_platform//\/}"
+        fi
+        echo "IMAGE_ID=${IMAGE_ID}"
+        echo "VERSION=${VERSION}"
+    
+        docker buildx build \
+          --platform linux/${{ matrix.platform }} \
+          --tag ${IMAGE_ID}:${VERSION} \
+          --file ./Dockerfile \
+          --output type=image,push=true .
+
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: build
+    env:
+      DOCKER_CLI_EXPERIMENTAL: enabled
+    steps:
+    - name: Get current branch
+      run: |
+        BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/\//_/g')
+        if [ "${BRANCH_NAME}" = "master" ]; then
+          BRANCH_NAME="latest"
+        fi
+        echo "::set-env name=BRANCH_NAME::${BRANCH_NAME}"
+    - run: |
+        IMAGE_ID=shiishii/raspap
+        
+        echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin
+        
+        docker manifest create ${IMAGE_ID}:${{ env.BRANCH_NAME }} \
+                               ${IMAGE_ID}:${{ env.BRANCH_NAME }}-amd64 \
+                               ${IMAGE_ID}:${{ env.BRANCH_NAME }}-arm64 \
+                               ${IMAGE_ID}:${{ env.BRANCH_NAME }}-armv7 \
+                               ${IMAGE_ID}:${{ env.BRANCH_NAME }}-ppc64le \
+                               ${IMAGE_ID}:${{ env.BRANCH_NAME }}-s390x \
+                               ${IMAGE_ID}:${{ env.BRANCH_NAME }}-386
+        
+        docker manifest push ${IMAGE_ID}:${{ env.BRANCH_NAME }}


### PR DESCRIPTION
A simple Workflow I've made that build docker image using the project secret (need to specify it in the repository settings) DOCKER_USER and DOCKER_PASSWORD.

You also need to change the two var in the yml file from IMAGE_ID=shiishii/raspap to IMAGE_ID=jrcichra/raspap-docker

It will build it on amd64, arm64, arm/v7 and 386 arch.
So it can be run on Raspberry pi 1, 2, 3 and 3b+, 4

Hope this help you.